### PR TITLE
Optimize(casbin): 优化casbin策略文件的路径

### DIFF
--- a/middleware/inject/inject.go
+++ b/middleware/inject/inject.go
@@ -20,13 +20,7 @@ func init() {
 	g := new(inject.Graph)
 
 	// 注入casbin
-	osType := runtime.GOOS
-	var path string
-	if osType == "windows" {
-		path = "conf\\rbac_model.conf"
-	} else if osType == "linux" || osType == "darwin" {
-		path = "conf/rbac_model.conf"
-	}
+	path := "conf/rbac_model.conf"
 	enforcer, _ := casbin.NewEnforcerSafe(path, false)
 	_ = g.Provide(&inject.Object{Value: enforcer})
 


### PR DESCRIPTION
“/”可以用在Windows和Linux上进行路径的分隔，是通用的，所以这里不用做区分的处理。